### PR TITLE
feat!(react18): release react-table on the npm registory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,12 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org/'
+      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
       - run: yarn install
       - run: yarn run valid
       - run: yarn run library:build
       - run: yarn run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "@table-library/react-table-library",
+  "name": "@appkitreact/react-table-library",
   "version": "0.0.0-development",
-  "description": "react-table-library",
+  "description": "fork of react-table-library to support react 18",
+  "private": false,
   "type": "module",
   "main": "main.js",
   "types": "index.d.ts",
@@ -143,19 +144,7 @@
   },
   "release": {
     "repositoryUrl": "https://github.com/lokeshjain2008/react-table-library.git",
-    "branches": ["master"],
-    "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
-      "@semantic-release/changelog",
-      [
-        "@semantic-release/github",
-        {
-          "successComment": false,
-          "failComment": false
-        }
-      ]
-    ]
+    "branches": ["master"]
   },
   "keywords": [
     "react",


### PR DESCRIPTION
This pull request introduces changes to configure publishing to npm, update metadata for a forked package, and simplify the release process. The most important changes include adding npm registry and authentication setup in the release workflow, updating the package name and description in `package.json`, and removing plugins from the semantic release configuration.

### Workflow configuration updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R17-R25): Added npm registry URL and authentication token setup to enable publishing to npm. Also included `NPM_TOKEN` as an environment variable for the semantic release step.

### Package metadata updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R5): Updated the `name` field to `@appkitreact/react-table-library` and the `description` field to indicate that this is a fork of the original library with React 18 support. Set the `private` field to `false` to allow publishing.

### Release process simplification:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L146-R147): Removed semantic release plugins (e.g., `@semantic-release/commit-analyzer`, `@semantic-release/github`) from the configuration, leaving only the `branches` field under the `release` section.