### PR TITLE
feat!: release react-table on npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,29 @@
   },
   "release": {
     "repositoryUrl": "https://github.com/lokeshjain2008/react-table-library.git",
-    "branches": ["master"]
+    "branches": ["master"],
+    "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "angular",
+      "releaseRules": [
+        {"type": "feat", "release": "minor"},
+        {"type": "fix", "release": "patch"},
+        {"type": "docs", "release": "patch"},
+        {"type": "style", "release": "patch"},
+        {"type": "refactor", "release": "patch"},
+        {"type": "perf", "release": "patch"},
+        {"breaking": true, "release": "major"},
+        {"type": "feat", "scope": "react18", "release": "minor"},
+        {"type": "feat!", "release": "major"}
+      ],
+      "parserOpts": {
+        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+      }
+    }],
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    "@semantic-release/github"
+  ]
   },
   "keywords": [
     "react",


### PR DESCRIPTION
This pull request updates the release configuration in the `package.json` file to enhance the semantic versioning process by integrating additional plugins and defining custom release rules.

### Release configuration updates:
* Added the `@semantic-release/commit-analyzer` plugin with a custom set of release rules based on commit types (e.g., `feat` triggers a minor release, `fix` triggers a patch release, and breaking changes trigger a major release). The plugin also includes parser options to recognize breaking change keywords.
* Integrated additional plugins: `@semantic-release/changelog`, `@semantic-release/npm`, and `@semantic-release/github` to automate changelog updates, npm publishing, and GitHub release creation.